### PR TITLE
Only display failed Checkov checks to reduce noise

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,5 @@ jobs:
 
       - name: Run Checkov
         uses: bridgecrewio/checkov-action@v12
+        with:
+          quiet: true


### PR DESCRIPTION
# Description

Checkov was outputting the results of all the checks, we don't need to see all the passed ones, it just makes it harder to find the important information.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

You can see the output here: https://github.com/uktrade/webops-sre-tooling/actions/runs/4576626274/jobs/8081007255

Before it was like this: https://github.com/uktrade/webops-sre-tooling/actions/runs/4563879998/jobs/8052929083

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
