### PR TITLE
Skip checks for terraform modules pinned to a branch

### DIFF
--- a/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
+++ b/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
@@ -122,7 +122,7 @@ checkov_test:
       if [ ! -f .checkov.baseline ]; then
         echo "{}" > .checkov.baseline
       fi
-    - checkov --output cli --quiet --directory . --baseline .checkov.baseline
+    - checkov --output cli --quiet --directory . --baseline .checkov.baseline --skip-check CKV_TF_1
 
 stages:
   - terraform_quality_checks

--- a/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
+++ b/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
@@ -65,7 +65,7 @@ tflint:
   script:
     - tflint --init
     - tflint --version
-    - tflint --recursive
+    - tflint --recursive --disable-rule terraform_module_pinned_source
 
 prevent_unchecked_dev_files:
   stage: terraform_quality_checks


### PR DESCRIPTION
# Description

Checkov complains when we download external modules without a commit hash. This skip allows us to reference external modules with the master/main branch. 
tflint also complains about the thing. So we've added a skip for that also. 

## Contributors

@yusufsheiqh 

## How this has been tested

The `terraform-aws-org` repo uses this skip check already: https://gitlab.ci.uktrade.digital/webops/terraform-aws-org/-/blob/master/.gitlab-ci.yml#L53

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
