### PR TITLE
Cloudwatch log retention period check skip

### DIFF
--- a/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
+++ b/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
@@ -125,7 +125,7 @@ checkov_test:
       if [ ! -f .checkov.baseline ]; then
         echo "{}" > .checkov.baseline
       fi
-    - checkov --output cli --quiet --directory . --baseline .checkov.baseline --skip-check CKV_TF_1 CKV_AWS_338
+    - checkov --output cli --quiet --directory . --baseline .checkov.baseline --skip-check CKV_TF_1,CKV2_AWS_338
 
 stages:
   - terraform_quality_checks

--- a/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
+++ b/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
@@ -125,7 +125,7 @@ checkov_test:
       if [ ! -f .checkov.baseline ]; then
         echo "{}" > .checkov.baseline
       fi
-    - checkov --output cli --quiet --directory . --baseline .checkov.baseline --skip-check CKV_TF_1,CKV2_AWS_338
+    - checkov --output cli --quiet --directory . --baseline .checkov.baseline --skip-check CKV_TF_1,CKV_AWS_338
 
 stages:
   - terraform_quality_checks

--- a/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
+++ b/gitlab-ci/terraform-quality-checks/gitlab-ci.yml
@@ -125,7 +125,7 @@ checkov_test:
       if [ ! -f .checkov.baseline ]; then
         echo "{}" > .checkov.baseline
       fi
-    - checkov --output cli --quiet --directory . --baseline .checkov.baseline --skip-check CKV_TF_1
+    - checkov --output cli --quiet --directory . --baseline .checkov.baseline --skip-check CKV_TF_1 CKV_AWS_338
 
 stages:
   - terraform_quality_checks


### PR DESCRIPTION
# Description

This adds a skip on cloud watch log retention period which is causing Checkov checks to fail. The check specifies that cloud watch logs need to be retained for a year which is not necessary in our infrastructure setup.

## Contributors

@shehzadashiq 

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

The changes were made and applied to a branch. When checks were run against the test branch the checks ran successfully.

<img width="402" alt="image" src="https://github.com/uktrade/webops-sre-tooling/assets/5746804/05914a59-7477-44a3-bbb0-26084984e13e">


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
